### PR TITLE
[FINAL][HOLD] OALSimpleAudio - add suspendAudio, unsuspendAudio

### DIFF
--- a/ObjectAL/ObjectAL/OALSimpleAudio.h
+++ b/ObjectAL/ObjectAL/OALSimpleAudio.h
@@ -489,4 +489,9 @@ SYNTHESIZE_SINGLETON_FOR_CLASS_HEADER(OALSimpleAudio);
  */
 - (void) resetToDefault;
 
+#pragma mark Suspend
+
+- (void) suspendAudio;
+- (void) unsuspendAudio;
+
 @end

--- a/ObjectAL/ObjectAL/OALSimpleAudio.m
+++ b/ObjectAL/ObjectAL/OALSimpleAudio.m
@@ -32,6 +32,7 @@
 #import "ARCSafe_MemMgmt.h"
 #import "OALAudioSession.h"
 #import "OpenALManager.h"
+#import "ALWrapper.h"
 
 // By default, reserve all 32 sources.
 #define kDefaultReservedSources 32
@@ -735,6 +736,24 @@ initFailed:
 - (bool) suspended
 {
 	return [OALAudioSession sharedInstance].suspended;
+}
+
+#pragma mark Suspend
+
+- (void) suspendAudio {
+    ALContext *alContext = [OpenALManager sharedInstance].currentContext;
+    ALCcontext *alcContext = alContext.context;
+
+    [ALWrapper makeContextCurrent:nil];
+    [ALWrapper suspendContext:alcContext];
+}
+
+- (void) unsuspendAudio {
+    ALContext *alContext = [OpenALManager sharedInstance].currentContext;
+    ALCcontext *alcContext = alContext.context;
+
+    [ALWrapper makeContextCurrent:alcContext];
+    [ALWrapper processContext:alcContext];
 }
 
 


### PR DESCRIPTION
to fix this: https://trello.com/c/bCTAXWzn/33-16-511-bugfix-audio-kills-games
based on this guy's solution: https://github.com/MonoGame/MonoGame/pull/3297/files

griffin: https://github.com/mindsnacks/griffin/pull/4129
CoreMS: https://github.com/mindsnacks/CoreMS/pull/1068

One note about our branching in this repo (and some other repos we have), the base branch we are using for griffin is `feature/framework`, which is divergent from `master` (there's no easy way to merge it into master, it can only reasonably _replace_ `master` i think)